### PR TITLE
Update greekListMaker.py

### DIFF
--- a/dictionaries/greekListMaker.py
+++ b/dictionaries/greekListMaker.py
@@ -679,7 +679,6 @@ data = [
 'traum',
 'treiskaidek',
 'trema',
-'tri',
 'troch',
 'trop',
 'tryp',


### PR DESCRIPTION
Removing "tri" from the Greek Roots list as it causes too many false positives.
